### PR TITLE
Move vga pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Your VGA connector requires five wires:
 * Pin 7: Green Return - connect to GND
 * Pin 8: Blue Return - connect to GND
 * Pin 13: H-Sync - connect to PB4
-* Pin 14: V-Sync - connect to PC4
+* Pin 14: V-Sync - connect to PB5
 
 The resistive divider needs to drop the 3.3V output down to 0.7V. Some
 monitors are more tolerant of over voltage than others. In a perfect world,

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ To exit GDB, you may need to press Ctrl-C multiple times, as it seems it can get
 
 Your VGA connector requires five wires:
 
-* Pin 1: Red - connect to PA5 via a resistive divider.
+* Pin 1: Red - connect to PF1 via a resistive divider.
 * Pin 2: Green - connect to PB7 via a resistive divider.
 * Pin 3: Blue - connect to PD3 via a resistive divider.
 * Pin 5: Ground - connect to GND
 * Pin 6: Red Return - connect to GND
 * Pin 7: Green Return - connect to GND
 * Pin 8: Blue Return - connect to GND
-* Pin 13: H-Sync - connect to PB6
+* Pin 13: H-Sync - connect to PB4
 * Pin 14: V-Sync - connect to PC4
 
 The resistive divider needs to drop the 3.3V output down to 0.7V. Some
@@ -161,12 +161,33 @@ the blue and red channels in exactly the same fashion.
 
 ### PS/2 Keyboard
 
-PS/2 keyboard support is mostly working. See the [pc-
-keyboard](https://github.com/thejpster/pc-keyboard) crate. Any UK 102-key or
-105-key keyboard should work. Be aware though, there's clearly an issue with
-the interrupt handling as about 10% of keystrokes get corrupted. Currently
-this displays an error on the screen, or perhaps as a double character when
-you only pressed a key once. I'm hoping to improve it.
+PS/2 keyboard support is mostly working, but consider it alpha grade. See the
+[pc- keyboard](https://github.com/thejpster/pc-keyboard) crate. Any UK 102-key
+or 105-key keyboard should work - support for other layouts welcome as a PR!
+
+Be aware, there's clearly an issue with the interrupt handling as about 10% of
+keystrokes get corrupted. Currently this displays an error on the screen, or
+perhaps as a double character when you only pressed a key once. I'm hoping to
+improve it.
+
+The pinout is:
+
+* +CLK: PA2
+* +DATA: PA4
+* Ground: GND
+* Vcc: 5V
+
+Tie PA3 (Keyboard Chip Select) to Ground.
+
+PS/2 keyboards have 5V I/O. It's specified as open-collector but keyboards
+sometimes contain internal pull-up resistors to 5V. All of the LM4F120/TM4C123
+I/O pins are 5V tolerant when in input mode (except PB0, PB1, PD4, PD5). You
+should probably add a 10k pull-up resistor to 5V on both +CLK and +DATA just
+in case your keyboard hasn't got one.
+
+Monotron currently doesn't support talking back to the keyboard (e.g. to turn
+the SCROLL, NUM and CAPS-LOCK lights on)- to do so would probably require more
+robust interface circuitry.
 
 ### UART
 
@@ -185,6 +206,7 @@ use 'exit' to return to the previous menu.
 
 ## Changelog
 
+* Version 0.6.0 - Changed pinout to move PS/2 keyboard to SPI interface
 * Version 0.5.0 - Added 1bpp graphics mode.
 * Version 0.4.0 - Added PS/2 keyboard support.
 * Version 0.3.0 - Backspace works.

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,1 @@
+source [find board/ek-lm4f120xl.cfg]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@
 //! * SSI0Fss for Keyboard Chip Select on PA3 / 2.09.
 //! * SSI0Rx for Keyboard Data on PA4 / 2.08
 //! * Timer1 Channel A PB4 is H-Sync
-//! * GPIO PC4 is V-Sync
+//! * GPIO PB5 is V-Sync
 
 #![no_main]
 #![feature(asm)]
@@ -199,7 +199,6 @@ fn main() -> ! {
 
     let mut porta = p.GPIO_PORTA.split(&sc.power_control);
     let mut portb = p.GPIO_PORTB.split(&sc.power_control);
-    let portc = p.GPIO_PORTC.split(&sc.power_control);
     let mut portd = p.GPIO_PORTD.split(&sc.power_control);
     let mut portf = p.GPIO_PORTF.split(&sc.power_control);
 
@@ -208,7 +207,7 @@ fn main() -> ! {
         .pb4
         .into_af_push_pull::<tm4c123x_hal::gpio::AF7>(&mut portb.control);
     // GPIO controlled V-Sync
-    let _v_sync = portc.pc4.into_push_pull_output();
+    let _v_sync = portb.pb5.into_push_pull_output();
     // Ssi1Tx
     let _red_data = portf
         .pf1
@@ -452,14 +451,14 @@ impl fb::Hardware for VideoHardware {
 
     /// Called when V-Sync needs to be high.
     fn vsync_on(&mut self) {
-        let gpio = unsafe { &*tm4c123x_hal::tm4c123x::GPIO_PORTC::ptr() };
-        unsafe { bb::change_bit(&gpio.data, 4, true) };
+        let gpio = unsafe { &*tm4c123x_hal::tm4c123x::GPIO_PORTB::ptr() };
+        unsafe { bb::change_bit(&gpio.data, 5, true) };
     }
 
     /// Called when V-Sync needs to be low.
     fn vsync_off(&mut self) {
-        let gpio = unsafe { &*tm4c123x_hal::tm4c123x::GPIO_PORTC::ptr() };
-        unsafe { bb::change_bit(&gpio.data, 4, false) };
+        let gpio = unsafe { &*tm4c123x_hal::tm4c123x::GPIO_PORTB::ptr() };
+        unsafe { bb::change_bit(&gpio.data, 5, false) };
     }
 
     /// Write pixels straight to FIFOs


### PR DESCRIPTION
Moves the VGA pins to:

* Pin 1: Red - connect to PF1 via a resistive divider.
* Pin 2: Green - connect to PB7 via a resistive divider.
* Pin 3: Blue - connect to PD3 via a resistive divider.
* Pin 5: Ground - connect to GND
* Pin 6: Red Return - connect to GND
* Pin 7: Green Return - connect to GND
* Pin 8: Blue Return - connect to GND
* Pin 13: H-Sync - connect to PB4
* Pin 14: V-Sync - connect to PB5
