### PR TITLE
Enable screen echo to USB_UART

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,12 +346,15 @@ impl Context {
 
     /// Write an 8-bit ASCII character to the screen.
     fn write_u8(&mut self, ch: u8) {
+        self.usb_uart.write(ch).unwrap();
         unsafe { FRAMEBUFFER.write_character(ch).unwrap() }
     }
 }
 
 impl core::fmt::Write for Context {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.usb_uart.write_all(s);
+        //self.usb_uart.write('\n' as u8).unwrap();
         unsafe { FRAMEBUFFER.write_str(s) }
     }
 }


### PR DESCRIPTION
I don't always have a VGA monitor to hand.

Enabling UART loopback of the screen allows for development on the go. 

``` shell
# Connect to the monotron in an understandable way
picocom -b 115200 --imap lfcrlf /dev/ttyACM0 -q
# The banner will still be screwed up but the REPL is readable
```
